### PR TITLE
Update S3 File System to support Path Style Buckets

### DIFF
--- a/AWS/InedoExtension/FileSystems/S3FileSystem.cs
+++ b/AWS/InedoExtension/FileSystems/S3FileSystem.cs
@@ -80,6 +80,13 @@ namespace Inedo.ProGet.Extensions.AWS.PackageStores
         [Persistent]
         [HideFromImporter]
         [Category("Advanced")]
+        [DisplayName("Enable Path Style for S3")]
+        [Description("Activate path-style URLs for accessing Amazon S3 buckets. Useful for compatibility with certain applications and services.")]
+        public bool UsePathStyle { get; set; };
+
+        [Persistent]
+        [HideFromImporter]
+        [Category("Advanced")]
         [DisplayName("Custom service URL")]
         [Description("Specifying a custom service URL will override the region endpoint.")]
         public string CustomServiceUrl { get; set; }
@@ -689,11 +696,18 @@ namespace Inedo.ProGet.Extensions.AWS.PackageStores
         {
             // https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-region-selection.html
             // example service URL is: https://ec2.us-west-new.amazonaws.com
+            var config = new AmazonS3Config();
 
             if (!string.IsNullOrEmpty(this.CustomServiceUrl))
-                return new AmazonS3Config { ServiceURL = this.CustomServiceUrl };
-            else
-                return new AmazonS3Config { RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(this.RegionEndpoint) };
+                config.ServiceURL = this.CustomServiceUrl;
+            else if (!string.IsNullOrEmpty(this.RegionEndpoint))
+                config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(this.RegionEndpoint);
+
+            // 
+            if (this.UsePathStyle)
+                config.ForcePathStyle = true;
+
+            return config;
         }
 
         private AmazonS3Client CreateClient()
@@ -771,3 +785,4 @@ namespace Inedo.ProGet.Extensions.AWS.PackageStores
         private static partial Regex MultiSlashPatternRegex();
     }
 }
+ 


### PR DESCRIPTION
This PR introduces support for path-style URLs when accessing S3 buckets via the AWS extension in ProGet.

A new advanced option, "Enable Path Style for S3", has been added to allow users to toggle this behavior. When enabled, the ForcePathStyle flag is set in the AmazonS3Config, enabling compatibility with S3-compatible services that require path-style addressing.

Many self-hosted or third-party object storage providers (e.g., MinIO, Wasabi, Backblaze B2) support the S3 API but require path-style requests instead of virtual-hosted-style URLs.
This change makes the plugin more flexible and broadly usable in hybrid or private cloud environments.

Notes:
- Default behavior remains unchanged to preserve backward compatibility
- This has been thoroughly tested on both MinIO and AWS S3